### PR TITLE
Automate Python workflow using pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+default_stages: [ commit ]
+repos:
+   # pre-commit is also configured to format yaml, trim whitespace, add new lines,
+   # check for merge conflicts, and checks for python debug statements.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: debug-statements
+
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        language_version: python3.9
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [ "flake8-print", "flake8-builtins", "flake8-functions==0.0.4" ]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: [ "--filter-files" ]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.1.1
+    hooks:
+    -   id: mypy
+        args: [--no-strict-optional, --ignore-missing-imports]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[isort]
+length_sort=1
+multi_line_output=3
+use_parentheses = True
+include_trailing_comma=True
+ensure_newline_before_comments = True
+filter_files = True
+profile=black
+sources = ["web"]
+
+[flake8]
+max-line-length = 127
+max-complexity = 10
+extend-ignore = W503, C901, E203, E722
+
+[mypy]
+ignore_missing_imports = True
+no_strict_optional = True


### PR DESCRIPTION
## How it works

![Automate code reviewing formatting](https://user-images.githubusercontent.com/1609440/225322667-a8736a5d-4427-4d58-80ba-a1b0944b48d1.png)

## How to use it

The code style guide can be enforced through `pre-commit` hooks. When cloning/setting up a new repo you will need to set up the hooks.

1. Download `pre-commit` by running `pip install pre-commit`
2. In the root of the repository run:
   ```commandline
   pre-commit install --hook-type pre-commit
   ```
Pre-commit runs when you commit files, if the formatting is not black-compliant or the code fails linting, the commit will be blocked.
In the case of formatting `black` will have run, and you will need to re-add the file(s), in the case of `flake8` you will need to sort out any linting issues and re-add the files to commit.
