### PR TITLE
Feature/add summarization

### DIFF
--- a/web/cat/looking_glass.py
+++ b/web/cat/looking_glass.py
@@ -1,6 +1,7 @@
 import time
 
 import langchain
+from langchain.chains.summarize import load_summarize_chain
 from cat.utils import log
 from cat.memory import VectorStore, VectorMemoryConfig
 from cat.db.database import get_db_session, create_db_and_tables
@@ -65,6 +66,9 @@ class CheshireCat:
         self.hypothetis_chain = langchain.chains.LLMChain(
             prompt=hypothesis_prompt, llm=self.llm, verbose=True
         )
+
+        # TODO: import chain_type from settings
+        self.summarization_chain = load_summarize_chain(self.llm, chain_type="map_reduce")
 
         # TODO: can input vars just be deducted from the prompt? What about plugins?
         self.input_variables = [
@@ -146,6 +150,12 @@ class CheshireCat:
         hyde_embedding = self.embedder.embed_query(hyde_text)
 
         return hyde_text, hyde_embedding
+
+    def get_summary_text(self, docs):
+        summary = self.summarization_chain.run(docs)
+        if self.verbose:
+            log(summary)
+        return summary
 
     def __call__(self, user_message):
         if self.verbose:

--- a/web/cat/rabbit_hole.py
+++ b/web/cat/rabbit_hole.py
@@ -31,6 +31,9 @@ def ingest_file(file: UploadFile, ccat):
         loader = PDFMinerLoader(temp_name)
         data = loader.load()
 
+    # example: pass data to cat to get summary
+    # summary = ccat.get_summary_text(data)
+
     # delete file
     os.remove(temp_name)
     log(len(data))

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -19,3 +19,4 @@ SQLAlchemy==1.4.41
 fastapi-utils==0.2.1
 sqlmodel==0.0.8
 faiss-cpu==1.7.3
+tiktoken==0.3.2


### PR DESCRIPTION
First iteration to close issue #49.

After studying a bit the [documentation](https://langchain.readthedocs.io/en/latest/modules/indexes/chain_examples/summarize.html) I decided to use "map_reduce" as a default chain_type that should scale well with large files.

I tested the method with a small .txt file (~800 words) and it worked smoothly.
I tried also to feed [alice.txt](https://github.com/pieroit/cheshire-cat/blob/7a242310f2e1dbb40455502c68dd8b21b82679de/alice.txt) but I got the following error:
```
openai.error.InvalidRequestError: This model's maximum context length is 4097 tokens. 
However, your messages resulted in 37730 tokens. Please reduce the length of the messages.
```

We should discuss a method to adopt in this or in a future PR to summarize large files without exceeding the maximum context length of llm. Also, right now the method accepts only documents but maybe we may need a more general summarizer that gets text in input (maybe text from the chat). We can opt to use a simple LLMChain for that purpose.


