### PR TITLE
added web/venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 __pycache__
 .env
 
+# python local dev
+web/venv
+
 .DS_Store
 .idea
 


### PR DESCRIPTION
Most python developers use a local python environment to get code lint (usually called venv).
Just added `web/venv` to .gitignore to allow that without any problem.