### PR TITLE
Use the Lifespan Events

### DIFF
--- a/web/cat/main.py
+++ b/web/cat/main.py
@@ -14,6 +14,10 @@ async def lifespan(app: FastAPI):
     #       ^._.^
     #
     # loads Cat and plugins
+    # Every endpoint can access the cat instance via request.app.state.ccat
+    # - Not using midlleware because I can't make it work with both http and websocket;
+    # - Not using Depends because it only supports callables (not instances)
+    # - Starlette allows this: https://www.starlette.io/applications/#storing-state-on-the-app-instance
     app.state.ccat = CheshireCat()
     yield
 

--- a/web/cat/main.py
+++ b/web/cat/main.py
@@ -8,18 +8,14 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from cat.looking_glass.cheshire_cat import CheshireCat
 
-cheshire_cat_resources = {}
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     #       ^._.^
     #
     # loads Cat and plugins
-    cheshire_cat_resources["cat"] = CheshireCat()
+    app.state.ccat = CheshireCat()
     yield
-    # Clean up Cat and plugins and release the resources
-    cheshire_cat_resources.clear()
 
 
 # REST API

--- a/web/cat/routes/memory.py
+++ b/web/cat/routes/memory.py
@@ -1,7 +1,5 @@
-
-from fastapi import Depends, Request, Response, APIRouter, HTTPException, status
-from fastapi import FastAPI, WebSocket, UploadFile, BackgroundTasks, Body, Query
-
+from fastapi import Query, Request, APIRouter
+from cat.main import cheshire_cat_resources
 
 router = APIRouter()
 
@@ -9,29 +7,23 @@ router = APIRouter()
 # DELETE delete_memories
 @router.delete("/{memory_id}/")
 async def delete_memories(memory_id: str):
-    """Delete specific memory. 
-    """
+    """Delete specific memory."""
     return {"error": "to be implemented"}
 
 
 # GET recall_memories
 @router.get("/recall/")
 async def recall_memories_from_text(
-        request: Request,
-        text: str = Query(description="Find memories similar to this text."),
-        k: int = Query(default=100, description="How many memories to return."),
-    ):
-    """Search k memories similar to given text. 
-    """
+    request: Request,
+    text: str = Query(description="Find memories similar to this text."),
+    k: int = Query(default=100, description="How many memories to return."),
+):
+    """Search k memories similar to given text."""
 
-    ccat = request.app.state.ccat
+    ccat = cheshire_cat_resources["cat"]
 
-    memories = ccat.recall_memories_from_text(
-        text=text, collection="episodes", k=k
-    )
-    documents = ccat.recall_memories_from_text(
-        text=text, collection="documents", k=k
-    )
+    memories = ccat.recall_memories_from_text(text=text, collection="episodes", k=k)
+    documents = ccat.recall_memories_from_text(text=text, collection="documents", k=k)
 
     memories = [dict(m[0]) | {"score": float(m[1])} for m in memories]
     documents = [dict(m[0]) | {"score": float(m[1])} for m in documents]

--- a/web/cat/routes/memory.py
+++ b/web/cat/routes/memory.py
@@ -1,5 +1,4 @@
 from fastapi import Query, Request, APIRouter
-from cat.main import cheshire_cat_resources
 
 router = APIRouter()
 
@@ -20,7 +19,7 @@ async def recall_memories_from_text(
 ):
     """Search k memories similar to given text."""
 
-    ccat = cheshire_cat_resources["cat"]
+    ccat = request.app.state.ccat
 
     memories = ccat.recall_memories_from_text(text=text, collection="episodes", k=k)
     documents = ccat.recall_memories_from_text(text=text, collection="documents", k=k)

--- a/web/cat/routes/upload.py
+++ b/web/cat/routes/upload.py
@@ -1,5 +1,4 @@
 from fastapi import Body, Request, APIRouter, UploadFile, BackgroundTasks
-from cat.main import cheshire_cat_resources
 from cat.utils import log
 from cat.rabbit_hole import ingest_file
 from fastapi.responses import JSONResponse
@@ -24,7 +23,7 @@ async def rabbithole_upload_endpoint(
     Chunks will be then vectorized and stored into documents memory.
     """
 
-    ccat = cheshire_cat_resources["cat"]
+    ccat = request.app.state.ccat
 
     log(f"Uploaded {file.content_type} down the rabbit hole")
 

--- a/web/cat/routes/websocket.py
+++ b/web/cat/routes/websocket.py
@@ -1,7 +1,6 @@
 import traceback
 
 from fastapi import APIRouter, WebSocket
-from cat.main import cheshire_cat_resources
 from cat.utils import log
 
 router = APIRouter()
@@ -10,7 +9,7 @@ router = APIRouter()
 # main loop via websocket
 @router.websocket_route("/ws")
 async def websocket_endpoint(websocket: WebSocket):
-    ccat = cheshire_cat_resources["cat"]
+    ccat = websocket.app.state.ccat
 
     await websocket.accept()
 

--- a/web/cat/routes/websocket.py
+++ b/web/cat/routes/websocket.py
@@ -1,14 +1,16 @@
 import traceback
-from cat.utils import log
+
 from fastapi import APIRouter, WebSocket
+from cat.main import cheshire_cat_resources
+from cat.utils import log
 
 router = APIRouter()
+
 
 # main loop via websocket
 @router.websocket_route("/ws")
 async def websocket_endpoint(websocket: WebSocket):
-
-    ccat = websocket.app.state.ccat
+    ccat = cheshire_cat_resources["cat"]
 
     await websocket.accept()
 

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,5 @@
 python-multipart==0.0.6
-fastapi==0.92.0
+fastapi==0.93.0
 fastapi-utils==0.2.1
 websockets==10.4
 SQLAlchemy==1.4.41


### PR DESCRIPTION
The Cat was loaded at the top level of the file, which means that it would load the model even if you are running a simple automated test, then that test would be slow because it would have to wait for the model to load before being able to run an independent part of the code.

That's what we'll solve. Let's load the model before the requests are handled, but only right before the application starts receiving requests, not while the code is being loaded.

