### PR TITLE
Feature/summarization

### DIFF
--- a/web/cat/looking_glass/cheshire_cat.py
+++ b/web/cat/looking_glass/cheshire_cat.py
@@ -69,7 +69,7 @@ class CheshireCat:
         )
 
         # TODO: import chain_type from settings
-        self.summarization_chain = load_summarize_chain(self.llm, chain_type="map_reduce")
+        self.summarization_chain = load_summarize_chain(self.llm, chain_type="stuff")
 
         # TODO: can input vars just be deducted from the prompt? What about plugins?
         self.input_variables = [
@@ -153,10 +153,11 @@ class CheshireCat:
         return hyde_text, hyde_embedding
 
     def get_summary_text(self, docs):
-        summary = self.summarization_chain.run(docs)
+        # TODO: should we summarize group of documents?
+        summaries = [self.summarization_chain.run([doc]) for doc in docs]
         if self.verbose:
-            log(summary)
-        return summary
+            log(summaries)
+        return summaries
 
     def __call__(self, user_message):
         if self.verbose:

--- a/web/cat/looking_glass/cheshire_cat.py
+++ b/web/cat/looking_glass/cheshire_cat.py
@@ -68,8 +68,18 @@ class CheshireCat:
             prompt=hypothesis_prompt, llm=self.llm, verbose=True
         )
 
+        
+        # TODO: we could import this from plugins
+        self.summarization_prompt = """Write a concise summary of the following:
+{text}
+"""
         # TODO: import chain_type from settings
-        self.summarization_chain = load_summarize_chain(self.llm, chain_type="stuff")
+        self.summarization_chain = load_summarize_chain(
+            self.llm, chain_type="stuff",
+            prompt=langchain.PromptTemplate(
+                template=self.summarization_prompt, input_variables=["text"]
+            )
+        )
 
         # TODO: can input vars just be deducted from the prompt? What about plugins?
         self.input_variables = [

--- a/web/cat/looking_glass/cheshire_cat.py
+++ b/web/cat/looking_glass/cheshire_cat.py
@@ -2,7 +2,7 @@ import time
 
 import langchain
 from langchain.chains.summarize import load_summarize_chain
-
+from langchain.docstore.document import Document
 from cat.db.database import get_db_session, create_db_and_tables
 from cat.looking_glass.agent_manager import AgentManager
 from cat.mad_hatter.mad_hatter import MadHatter
@@ -162,12 +162,17 @@ class CheshireCat:
 
         return hyde_text, hyde_embedding
 
-    def get_summary_text(self, docs):
-        # TODO: should we summarize group of documents?
-        summaries = [self.summarization_chain.run([doc]) for doc in docs]
+    def get_summary_text(self, docs, group_size=3):
+        flag = False
+        while not flag:
+            # TODO: should we save intermediate results?
+            docs = [self.summarization_chain.run(docs[i:i+group_size]) for i in range(0,len(docs), group_size)]
+            docs = [Document(page_content=doc) for doc in docs]
+            flag = len(docs)==1
+
         if self.verbose:
-            log(summaries)
-        return summaries
+            log(docs[0])
+        return docs[0]
 
     def __call__(self, user_message):
         if self.verbose:

--- a/web/cat/rabbit_hole.py
+++ b/web/cat/rabbit_hole.py
@@ -54,8 +54,7 @@ def ingest_file(ccat: CheshireCat, file: UploadFile, chunk_size: int = 400, chun
     log(f"Preparing to memorize {len(docs)} vectors")
 
 
-    # TODO: hierarchical summarization
-    # example: pass data to cat to get summary
+    # iterative summarization 
     # summary = ccat.get_summary_text(docs)
 
 

--- a/web/cat/rabbit_hole.py
+++ b/web/cat/rabbit_hole.py
@@ -56,7 +56,7 @@ def ingest_file(ccat: CheshireCat, file: UploadFile, chunk_size: int = 400, chun
 
     # TODO: hierarchical summarization
     # example: pass data to cat to get summary
-    summary = ccat.get_summary_text(docs)
+    # summary = ccat.get_summary_text(docs)
 
 
     # classic embed

--- a/web/cat/rabbit_hole.py
+++ b/web/cat/rabbit_hole.py
@@ -56,7 +56,7 @@ def ingest_file(ccat: CheshireCat, file: UploadFile, chunk_size: int = 400, chun
 
     # TODO: hierarchical summarization
     # example: pass data to cat to get summary
-    # summary = ccat.get_summary_text(data)
+    summary = ccat.get_summary_text(docs)
 
 
     # classic embed

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -14,3 +14,4 @@ beautifulsoup4==4.12.0
 pdfminer.six==20221105
 unstructured==0.5.7
 faiss-cpu==1.7.3
+tiktoken==0.3.3


### PR DESCRIPTION
Another step forward to solve #16.

I added a prompt for the default summarization method that can be imported from plugins (also changed chain type from "map_reduce" to "stuff").

I tested the new text_splitter and it works great, the problem of reaching maximum token is solved now.
We can talk about passing a group of documents instead of just one document, this could help implement hierarchical summarization very easily (if we iterate this step on the output).