### PR TITLE
Huggingface/hf hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ When you're done, remember to CTRL+c in the terminal and
 docker-compose down
 ```
 
+### Cheshire-Cat Loves HuggingFace
+
+If you want to use HuggingFace Hub instead of OpenAI, create a `.env` file containing:
+
+```
+HF_TOKEN=<your-huggingface-token>
+HF_CHECKPOINT=<selected-checkpoint>
+```
+
+example:
+
+```
+HF_TOKEN=hf_yourtoken
+HF_CHECKPOINT=decapoda-research/llama-13b-hf
+```
+
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 

--- a/web/cat/config/embedder.py
+++ b/web/cat/config/embedder.py
@@ -35,7 +35,18 @@ class EmbedderOpenAIConfig(EmbedderSettings):
         description = "Configuration for OpenAI embeddings"
 
 
+class EmbedderHuggingFaceHubConfig(EmbedderSettings):
+    # repo_id: str = None
+    huggingfacehub_api_token: str
+    _pyclass: PyObject = langchain.embeddings.HuggingFaceHubEmbeddings
+
+    class Config:
+        title = "HuggingFace Hub Embedder"
+        description = "Configuration for HuggingFace Hub embeddings"
+
+
 SUPPORTED_EMDEDDING_MODELS = [
     EmbedderFakeConfig,
     EmbedderOpenAIConfig,
+    EmbedderHuggingFaceHubConfig,
 ]

--- a/web/cat/config/embedder.py
+++ b/web/cat/config/embedder.py
@@ -36,7 +36,7 @@ class EmbedderOpenAIConfig(EmbedderSettings):
 
 
 class EmbedderHuggingFaceHubConfig(EmbedderSettings):
-    # repo_id: str = None
+    # repo_id: str = None TODO use the default sentence-transformers at the moment
     huggingfacehub_api_token: str
     _pyclass: PyObject = langchain.embeddings.HuggingFaceHubEmbeddings
 

--- a/web/cat/plugins/quickstart_cat_plugin/models.py
+++ b/web/cat/plugins/quickstart_cat_plugin/models.py
@@ -20,6 +20,13 @@ def get_language_model(cat):
                 # "model_name": "gpt-3.5-turbo" # TODO: allow optional kwargs
             }
         )
+    elif "HF_TOKEN" in os.environ:
+        llm = llms.LLMHuggingFaceHubConfig.get_llm_from_config(
+            {
+                "huggingfacehub_api_token": os.environ["HF_TOKEN"],
+                "repo_id" : os.environ["HF_CHECKPOINT"]
+            }
+        )
     else:
         llm = llms.LLMDefaultConfig.get_llm_from_config({})
 
@@ -37,6 +44,13 @@ def get_language_embedder(cat):
             {
                 "openai_api_key": os.environ["OPENAI_KEY"],
                 # model_name: '....'  # TODO: allow optional kwargs
+            }
+        )
+    elif "HF_TOKEN" in os.environ:
+        embedder = embedders.EmbedderHuggingFaceHubConfig.get_embedder_from_config(
+            {
+                "huggingfacehub_api_token": os.environ["HF_TOKEN"],
+                # repo_id: "..." TODO: at the moment use default
             }
         )
     else:


### PR DESCRIPTION
** Integration with HuggingFace Hub**
Issue #66 

Developed the support for huggingface hub:
* updated the hooks in [models.py](https://github.com/pieroit/cheshire-cat/blob/main/web/cat/plugins/quickstart_cat_plugin/models.py#L30)
* Developed the embedder for huggingface hub using langchain
* tested with some models: 
  * [openai-gpt](https://huggingface.co/openai-gpt), 
  * [llama](decapoda-research/llama-13b-hf), 
  * [alpaca-lora](https://huggingface.co/declare-lab/flan-alpaca-xxl)
* updated readme