### PR TITLE
Added custom summarization chain

### DIFF
--- a/web/cat/looking_glass/cheshire_cat.py
+++ b/web/cat/looking_glass/cheshire_cat.py
@@ -80,6 +80,15 @@ class CheshireCat:
                 template=self.summarization_prompt, input_variables=["text"]
             ),
         )
+        
+        # custom summarization chain
+        self.custom_summarization_chain = langchain.chains.LLMChain(
+            llm=self.llm,
+            verbose=False,
+            prompt=langchain.PromptTemplate(
+                template=self.summarization_prompt, input_variables=["text"]
+            ),
+        )
 
         # TODO: can input vars just be deducted from the prompt? What about plugins?
         self.input_variables = [
@@ -163,19 +172,21 @@ class CheshireCat:
         return hyde_text, hyde_embedding
 
     # iterative summarization
-    def get_summary_text(self, docs, group_size=3):
+    def get_summary_text(self, docs, group_size=3, custom=True):
         # service variable to store intermediate results
         intermediate_summaries = docs
 
         # we will store iterative summaries all together in a list
         all_summaries = []
+        
+        summarization_chain = self.custom_summarization_chain if custom else self.summarization_chain
 
         # loop until there are no groups to summarize
         root_summary_flag = False
         while not root_summary_flag:
             # make summaries of groups of docs
             intermediate_summaries = [
-                self.summarization_chain.run(intermediate_summaries[i : i + group_size])
+                summarization_chain.run(intermediate_summaries[i : i + group_size])
                 for i in range(0, len(intermediate_summaries), group_size)
             ]
             intermediate_summaries = [


### PR DESCRIPTION
I added a very simple custom summary chain.
Right now is possible to decide which one to use through a parameter in the method get_summary_text(...) but after some tests, I saw that they are equal in time and results, we can opt to leave only the custom chain.

The only pro of using the langchain summarization function could be tuning chain_type. 