### PR TITLE
Add optional APIs auth, close #83

### DIFF
--- a/web/cat/api_auth.py
+++ b/web/cat/api_auth.py
@@ -1,0 +1,14 @@
+from fastapi import Header, Security, Depends, HTTPException
+from fastapi.security.api_key import APIKeyHeader
+import os
+
+API_KEY = [key.strip() for key in os.getenv("API_KEY", "").split("|") if key.strip()]
+api_key_header = APIKeyHeader(name="access_token", auto_error=False)
+
+def check_api_key(api_key: str = Security(api_key_header)):
+    if not API_KEY:
+        return None
+    if api_key in API_KEY:
+        return api_key
+    else:
+        raise HTTPException(status_code=403, detail="Invalid API Key")

--- a/web/cat/main.py
+++ b/web/cat/main.py
@@ -1,13 +1,14 @@
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from cat.routes import base, memory, upload, websocket
 from fastapi.responses import JSONResponse
 from cat.routes.openapi import get_openapi_configuration_function
 from cat.routes.setting import llm_setting, general_setting, embedder_setting
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from cat.api_auth import check_api_key
 from cat.looking_glass.cheshire_cat import CheshireCat
 
 
@@ -25,7 +26,7 @@ async def lifespan(app: FastAPI):
 
 
 # REST API
-cheshire_cat_api = FastAPI(lifespan=lifespan)
+cheshire_cat_api = FastAPI(lifespan=lifespan, dependencies=[Depends(check_api_key)])
 
 
 # Configures the CORS middleware for the FastAPI app

--- a/web/cat/routes/openapi.py
+++ b/web/cat/routes/openapi.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
+import os
+
+API_KEY = os.getenv("API_KEY")
 
 
 def get_openapi_configuration_function(cheshire_cat_api: FastAPI):
-
     # Configure openAPI schema for swagger and redoc
     def custom_openapi():
         if cheshire_cat_api.openapi_schema:
@@ -19,12 +21,27 @@ def get_openapi_configuration_function(cheshire_cat_api: FastAPI):
         openapi_schema["info"]["x-logo"] = {
             "url": "https://github.com/pieroit/cheshire-cat/blob/main/cheshire-cat.jpeg?raw=true"
         }
+        if not API_KEY:
+            openapi_schema["components"]["securitySchemes"] = None
+            openapi_schema["paths"]["/"]["get"]["security"] = None
+            openapi_schema["paths"]["/settings/"]["get"]["security"] = None
+            openapi_schema["paths"]["/settings/"]["post"]["security"] = None
+            openapi_schema["paths"]["/settings/{settingId}"]["get"]["security"] = None
+            openapi_schema["paths"]["/settings/{settingId}"]["delete"]["security"] = None
+            openapi_schema["paths"]["/settings/{settingId}"]["patch"]["security"] = None
+            openapi_schema["paths"]["/settings/llm/"]["get"]["security"] = None
+            openapi_schema["paths"]["/settings/llm/{languageModelName}"]["put"]["security"] = None
+            openapi_schema["paths"]["/settings/embedder/"]["get"]["security"] = None
+            openapi_schema["paths"]["/settings/embedder/{languageEmbedderName}"]["put"]["security"] = None
+            openapi_schema["paths"]["/memory/recall/"]["get"]["security"] = None
+            openapi_schema["paths"]["/memory/{memory_id}/"]["delete"]["security"] = None
+            openapi_schema["paths"]["/rabbithole/"]["post"]["security"] = None
         # Defines preconfigured examples for swagger
         # This example set parameter of /settings/ get: 'limit' to 3, page to 2 and search to "XYZ"
         # openapi_schema["paths"]["/settings/"]["get"]["parameters"][0]["example"] = 3
-        # openapi_schema["paths"]["/settings/"]["get"]["parameters"][0]["example"] = 2
+        # openapi_schema["paths"]["/settings/"]["get"]["parameters"][1]["example"] = 2
         # openapi_schema["paths"]["/settings/"]["get"]["parameters"][2]["example"] = "XYZ"
         cheshire_cat_api.openapi_schema = openapi_schema
         return cheshire_cat_api.openapi_schema
-    
+
     return custom_openapi


### PR DESCRIPTION
API_KEY accept multiple keys pipe separated and is optional.

Notice: Swagger changes its behavior depending on whether or not the key is in the .env file. To achieve this we have to keep track of new routes and update the openapi.py file as well or some routes will be flagged as "protected" in the docs also if they are not. 

```.env``` EG.
```bash
API_KEY=key1|key2 | key3 |key4
```

Next step, after pr is merged, write some docs about optional api auth.