### PR TITLE
Small refactor of RabbitHole class

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -234,10 +234,15 @@ class CheshireCat:
         :param chunk_overlap: number of overlapping characters between consecutive chunks
         """
 
-        # Load the file in the cat memory
-        self.rabbit_hole.ingest_file(
-            self, file=file, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+        # split file into a list of docs
+        docs = RabbitHole.file_to_docs(
+            file=file, chunk_size=chunk_size, chunk_overlap=chunk_overlap
         )
+
+        # get summary and store in memory
+        summary, intermediate_summaries = self.get_summary_text(docs)
+        docs = [summary] + intermediate_summaries + docs
+        RabbitHole.store_documents(ccat=self, docs=docs, source=file.filename)
 
     def __call__(self, user_message):
         if self.verbose:


### PR DESCRIPTION
I split the original method into two methods:
- `file_to_docs` which, given a file chunks it into Documents
- `store_documents` which, given a list of Documents, stores them in memory

The next step is to create a list of documents from an URL, the method used to store them in memory will be the same. (maybe we can refactor further and put the store method inside the cat, let me know)