### PR TITLE
Added url ingestion endpoint + cat

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -226,6 +226,29 @@ class CheshireCat:
             filename = file.filename
         RabbitHole.store_documents(ccat=self, docs=docs, source=filename)
 
+    def send_url_in_rabbit_hole(
+        self,
+        url: str,
+        chunk_size: int = 400,
+        chunk_overlap: int = 100,
+    ):
+        """
+        Load a given website in the Cat's memory.
+        :param url: URL of the website to which you want to save the content
+        :param chunk_size: number of characters the text is split in
+        :param chunk_overlap: number of overlapping characters between consecutive chunks
+        """
+        
+        # get website content and split into a list of docs
+        docs = RabbitHole.url_to_docs(
+            url=url, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+        )
+        
+        #get summaries and store
+        summary, intermediate_summaries = self.get_summary_text(docs)
+        docs = [summary] + intermediate_summaries + docs
+        RabbitHole.store_documents(ccat=self, docs=docs, source=url)
+
     def __call__(self, user_message):
         if self.verbose:
             log(user_message)

--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -11,6 +11,7 @@ from langchain.document_loaders import (
     PDFMinerLoader,
     UnstructuredFileLoader,
     UnstructuredMarkdownLoader,
+    UnstructuredURLLoader,
 )
 from langchain.docstore.document import Document
 
@@ -18,6 +19,32 @@ from langchain.docstore.document import Document
 class RabbitHole:
     def __init__(self):
         pass
+    
+    @staticmethod
+    def url_to_docs(
+        url: str,
+        chunk_size: int = 400,
+        chunk_overlap: int = 100,
+    ) -> List[Document]:
+        """
+        Scrape website content and chunk it to a list of Documents.
+        :param url: URL of the website to which you want to save the content
+        :param chunk_size: number of characters the text is split in
+        :param chunk_overlap: number of overlapping characters between consecutive chunks
+        """
+
+        # load text content of the website
+        loader = UnstructuredURLLoader(urls=[url])
+        text = loader.load()
+
+        # split in documets using chunk_size and chunk_overlap
+        text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            separators=["\\n\\n", "\n\n", ".\\n", ".\n", "\\n", "\n", " ", ""],
+        )
+        docs = text_splitter.split_documents(text)
+        return docs
 
     @staticmethod
     def file_to_docs(

--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -52,3 +52,29 @@ async def rabbithole_upload_endpoint(
         "content-type": file.content_type,
         "info": "File is being ingested asynchronously.",
     }
+
+@router.post("/web/")
+async def rabbithole_url_endpoint(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    url: str = Body(description="URL of the website to which you want to save the content"),
+    chunk_size: int = Body(
+        default=400,
+        description="Maximum length of each chunk after the document is split (in characters)",
+    ),
+    chunk_overlap: int = Body(default=100, description="Chunk overlap (in characters)"),
+):
+    
+    #TODO do we need to check that URL is valid?
+    
+    ccat = request.app.state.ccat
+    
+    # upload file to long term memory, in the background
+    background_tasks.add_task(
+        ccat.send_url_in_rabbit_hole, url, chunk_size, chunk_overlap
+    )
+
+    return {
+        "url": url,
+        "info": "Website is being ingested asynchronously"
+    }


### PR DESCRIPTION
Backend implementation to solve #125
Waiting for frontend implementation to close the issue

I added a new endpoint `POST /rabbithole/web/` that accepts an _url_ to ingest.
The process is identical to file ingestion: Loader --> Splitter --> Summary --> Store

I tested it with the Wikipedia article on LLMs using chatgpt.
Many documents inserted in memory are actually useless, they contain Wikipedia information like the table of contents and etc... it shouldn't create too many problems, a way to solve this issue is to store only summaries. 

<img width="656" alt="Screenshot 2023-04-18 alle 12 31 52" src="https://user-images.githubusercontent.com/49289653/232753805-5ddd2a80-6be9-4d8d-8bf7-920bc5a40d21.png">
<img width="892" alt="Screenshot 2023-04-18 alle 12 31 13" src="https://user-images.githubusercontent.com/49289653/232753824-54082e6d-d544-4383-88fc-db878e9f9a39.png">