### PR TITLE
WiP: refactor core Dockerfile

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,9 +1,12 @@
-# TODO: better start with a cuda image? Dunno
-FROM tiangolo/uvicorn-gunicorn:python3.10
-
-RUN apt-get update -y
-#RUN apt-get install -y poppler-utils tesseract-ocr libreoffice ### needed form unstructured?
-
+FROM python:3.10.11-slim-bullseye
+ENV PYTHONUNBUFFERED=1
 COPY ./requirements.txt requirements.txt
-RUN pip install -U pip
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -U pip && pip install --no-cache-dir -r requirements.txt
+WORKDIR /app
+COPY . /app
+# Run uvicorn under non-root user
+RUN adduser --disabled-password --gecos '' appuser
+USER appuser
+EXPOSE 1865
+#CMD ["uvicorn", "cat.main:cheshire_cat_api", "--host", "0.0.0.0", "--port", "80", "--log-config", "./logger.yml"]
+CMD ["uvicorn", "cat.main:cheshire_cat_api", "--log-config", "./logger.yml"]

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,3 +1,5 @@
+uvicorn[standard]==0.20.0
+gunicorn==20.1.0
 python-multipart==0.0.6
 fastapi==0.93.0
 fastapi-utils==0.2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,11 @@ services:
       - .env
     environment:
       - PYTHONUNBUFFERED=1
+      - SQLITE_DATABASE_URL=sqlite:///database/metadata-v3.db
     ports:
       - ${CORE_PORT}:80
     volumes:
-      - ./core:/app
+      - ./database:/app/database
     command:
       - uvicorn
       - cat.main:cheshire_cat_api


### PR DESCRIPTION
Using the python:3.10.11-slim-bullseye base image to:
 * be able to build for other platforms in addition to amd64 (important for Apple Silicon).
 * make it possible to have reproducible images

The core application is now copied inside the container image and it is not mounted at runtime in a volume.

From Kubernetes docs:
https://kubernetes.io/docs/concepts/containers/

Containers are intended to be stateless and immutable: you should not change the code of a container that is already running. If you have a containerized application and want to make changes, the correct process is to build a new image that includes the change, then recreate the container to start from the updated image.

Related docs on the choice of the base image:
https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#-warning-you-probably-dont-need-this-docker-image

Creating `appuser` to prevent the application to run as root in the container

Dropping the unused `apt-get update` call that was increasing the container image size.