### PR TITLE
WiP: Refactor the admin container to be immutable

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,8 +1,20 @@
-FROM node:18
+FROM node:18.16.0-bullseye-slim
 
+COPY . /app
 # Create app directory
 WORKDIR /app
+RUN adduser --disabled-password --gecos '' appuser
+RUN chown -R appuser:appuser /app
+RUN chmod 755 /app
+USER appuser
+WORKDIR /app
 
+#ENV NODE_ENV=production
+#RUN npm ci --only=production ; npm run build # Review package.json for promotion of devDependencies
+RUN npm install
 # Expose port 3000 and build + start application
 EXPOSE 3000
-CMD ["/bin/bash", "-c", "npm install; npm run dev"]
+# Run npm as our non-root user
+
+#CMD ["/bin/bash", "-c", "npm run start"] # Review package.json for promotion of devDependencies
+CMD ["/bin/bash", "-c", "npm run dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
       - .env
     ports:
       - ${ADMIN_PORT}:3000
-    volumes:
-      - ./admin:/app
     restart: unless-stopped
 
   vector-memory:


### PR DESCRIPTION
From Kubernetes docs:
https://kubernetes.io/docs/concepts/containers/

Containers are intended to be stateless and immutable: you should not change the code of a container that is already running. If you have a containerized application and want to make changes, the correct process is to build a new image that includes the change, then recreate the container to start from the updated image.