### PR TITLE
fix: FastAPI returns an HTTP 307 when trailing slash is missing

### DIFF
--- a/admin/src/config.ts
+++ b/admin/src/config.ts
@@ -9,14 +9,14 @@ const CORE_USE_SECURE_PROTOCOLS = import.meta.env.CORE_USE_SECURE_PROTOCOLS as s
 const endpoints_list = {
   secure : {
     chat: `wss://${CORE_HOST}:${CORE_PORT}/ws`,
-    rabbitHole: `https://${CORE_HOST}:${CORE_PORT}/rabbithole`,
+    rabbitHole: `https://${CORE_HOST}:${CORE_PORT}/rabbithole/`,
     allLLM: `https://${CORE_HOST}:${CORE_PORT}/settings/llm/`,
     singleLLM: `https://${CORE_HOST}:${CORE_PORT}/settings/llm/:llm`,
     plugins: `https://${CORE_HOST}:${CORE_PORT}/plugins/`
   },
   unsecure : {
     chat: `ws://${CORE_HOST}:${CORE_PORT}/ws`,
-    rabbitHole: `http://${CORE_HOST}:${CORE_PORT}/rabbithole`,
+    rabbitHole: `http://${CORE_HOST}:${CORE_PORT}/rabbithole/`,
     allLLM: `http://${CORE_HOST}:${CORE_PORT}/settings/llm/`,
     singleLLM: `http://${CORE_HOST}:${CORE_PORT}/settings/llm/:llm`,
     plugins: `http://${CORE_HOST}:${CORE_PORT}/plugins/`


### PR DESCRIPTION
This change prevents a round trip for every HTTP request to the rabbithole endpoint.

This also fixes an issue when the endpoints are HTTPS: https://stackoverflow.com/questions/63511413/fastapi-redirection-for-trailing-slash-returns-non-ssl-link