### PR TITLE
WiP: A faster pdf Rabbit Hole with PyPDFLoader without summaries

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -171,8 +171,8 @@ class CheshireCat:
         )
 
         # get summaries
-        summary, intermediate_summaries = self.get_summary_text(docs)
-        docs = [summary] + intermediate_summaries + docs
+        #summary, intermediate_summaries = self.get_summary_text(docs)
+        #docs = [summary] + intermediate_summaries + docs
 
         # store in memory
         if isinstance(file, str):

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -15,3 +15,4 @@ beautifulsoup4==4.12.0
 pdfminer.six==20221105
 unstructured==0.5.7
 tiktoken==0.3.3
+pypdf==3.8.1


### PR DESCRIPTION
Do not merge. This PR is to discuss about the Rabbit Hole speed to ingest pdfs

Should summaries be active by default ?

PyPDFLoader seems to be way faster to slip the pdf into pages.