### PR TITLE
[BUGFIX] - Don't attempt to store an empty page content

### DIFF
--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -141,12 +141,14 @@ class RabbitHole:
             doc = ccat.mad_hatter.execute_hook(
                 "rabbit_hole_before_inserting_doc_in_vector_memory", doc
             )
-
-            _ = ccat.memory.vectors.declarative.add_texts(
-                [doc.page_content],
-                [doc.metadata],
-            )
-            log(f"Inserted into memory ({d + 1}/{len(docs)}):    {doc.page_content}")
+            if doc.page_content != "":
+                _ = ccat.memory.vectors.declarative.add_texts(
+                    [doc.page_content],
+                    [doc.metadata],
+                )
+                log(f"Inserted into memory ({d + 1}/{len(docs)}):    {doc.page_content}")
+            else:
+                log(f"Skipped memory insertion of empty page content ({d + 1}/{len(docs)})")
             time.sleep(0.1)
 
         # notify client


### PR DESCRIPTION
Passing a empty string as doc.page_content will result in a HTTP 400 error from the embeddings API

```
[2023-05-10 09:12:31,770] DEBUG  util.py 60 -=> message='OpenAI API response' path=https://<redacted>.openai.azure.com//openai/deployments/text-embedding-ada-002/embeddings?api-version=2022-12-01 processing_ms=23.877 request_id=992906f8-d56c-467e-a554-48e1f8f11a9a response_code=400
[2023-05-10 09:12:31,771] INFO   util.py 67 -=> error_code=None error_message="[''] is not valid under any of the given schemas - 'input'" error_param=None error_type=invalid_request_error message='OpenAI API error received' stream_error=False
```