### PR TITLE
fix(log): no break colors

### DIFF
--- a/core/cat/mad_hatter/decorators.py
+++ b/core/cat/mad_hatter/decorators.py
@@ -42,7 +42,6 @@ def hook(_func=None, priority=1) -> Any:
             doc_string = ""
         CatHooks.add_hook(
             {
-                "hook_function": cat_hook_wrapper,
                 "hook_name": func.__name__,
                 "docstring": func.__doc__,
                 "priority": float(priority),

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -1,3 +1,5 @@
+"""Various utiles used from the projects."""
+
 from datetime import timedelta
 import inspect
 import logging
@@ -9,7 +11,9 @@ logging.basicConfig(level=logging.DEBUG)
 
 def get_caller_info(skip=2):
     """Get the name of a caller in the format module.class.method.
+
     Copied from: https://gist.github.com/techtonik/2151727
+
     :arguments:
         - skip (integer): Specifies how many levels of stack
                           to skip while getting caller name.
@@ -57,8 +61,10 @@ def get_caller_info(skip=2):
 
 
 def log(msg):
+    """Print the log with the terminal colors."""
     (package, module, klass, caller, line) = get_caller_info()
     color_code = "38;5;219"
+    reset_code = "\x1b[0m"
 
     msg_header = "----------------  ^._.^  ----------------"
     msg_body = pformat(msg)
@@ -68,12 +74,12 @@ def log(msg):
         f"\u001b[{color_code}m\033[0.1m{msg_header}\u001b[0m => {package}.{module}.py ({klass}.{caller}(...)) @ {line} line"
     )
     for line in msg_body.splitlines():
-        logging.debug(f"\u001b[{color_code}m\033[0.1m{line}")
-    logging.debug(f"\u001b[{color_code}m\033[0.1m{msg_footer}")
+        logging.debug(f"\u001b[{color_code}m\033[0.1m{line}{reset_code}")
+    logging.debug(f"\u001b[{color_code}m\033[0.1m{msg_footer}{reset_code}")
 
 
-# Takes in a string of words separated by either hyphens or underscores and returns a string of words in camel case
 def to_camel_case(text):
+    """Take in a string of words separated by either hyphens or underscores and returns a string of words in camel case."""
     s = text.replace("-", " ").replace("_", " ").capitalize()
     s = s.split()
     if len(text) == 0:
@@ -81,22 +87,21 @@ def to_camel_case(text):
     return s[0] + "".join(i.capitalize() for i in s[1:])
 
 
-
 def verbal_timedelta(td):
+    """Convert a timedelta in human form."""
     if td.days != 0:
         abs_days = abs(td.days)
         if abs_days > 7:
-            abs_delta = '{} weeks'.format(td.days // 7)
+            abs_delta = "{} weeks".format(td.days // 7)
         else:
-            abs_delta = '{} days'.format(td.days)
+            abs_delta = "{} days".format(td.days)
     else:
         abs_minutes = abs(td.seconds) // 60
         if abs_minutes > 60:
-            abs_delta = '{} hours'.format(abs_minutes // 60)
+            abs_delta = "{} hours".format(abs_minutes // 60)
         else:
-            abs_delta = '{} minutes'.format(abs_minutes)
+            abs_delta = "{} minutes".format(abs_minutes)
     if td < timedelta(0):
-        return '{} ago'.format(abs_delta)
+        return "{} ago".format(abs_delta)
     else:
-        return '{} ago'.format(abs_delta)
-
+        return "{} ago".format(abs_delta)


### PR DESCRIPTION
Now the output is:
![immagine](https://github.com/pieroit/cheshire-cat/assets/403283/f4ff0787-6f07-4c86-b7d8-eb129615784a)
Not this mess:
![immagine](https://github.com/pieroit/cheshire-cat/assets/403283/217d4553-795f-4a0c-a2c5-451ee01cad44)

Also remove the hook_function parameter in the log https://github.com/pieroit/cheshire-cat/issues/180 as today is just the address memory doesn't give any useful information to the developer. We already know that for that plugin is loading that hook as the hook name is printed so we don't need that value.
In this way the log starts to have the stuff useful in the log.

I have added a bit of documentation to the utils.py file as I working on that.