### PR TITLE
fix(qdrant): alert user when qdrant don't respond

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
   cheshire-cat-vector-memory:
     image: qdrant/qdrant:v1.1.1
     container_name: cheshire_cat_vector_memory
-    expose:
-      - 6333
+    ports:
+      - 6333:6333
     volumes:
       - ./long_term_memory/vector:/qdrant/storage
     restart: unless-stopped


### PR DESCRIPTION
The idea is to do a socket request to check if qdrant respond, otherwise block the cat execution to avoid a long traceback useless to the user.

Fix: #205 