### PR TITLE
Added FAQ on Virtual Machine config to run the Cat

### DIFF
--- a/mkdocs/faq.md
+++ b/mkdocs/faq.md
@@ -53,6 +53,16 @@ ADMIN_PORT=2222
 #### Docker has no permissions to write
 This is a matter with your docker installation or the user you run docker from.
 
+#### The Cat seems not to be working from inside a Virtual Machine
+In VirtualBox you can select Settings->Network, then choose NAT in the "Attached to" drop down menu. Select "Advanced" to configure the port forwarding rules. Assuming the guest IP of your VM is 10.0.2.15 (the default) and the ports configred in the .env files are the defaults, you have to set at least the following rules:
+
+| Rule name | Protocol | Host IP     | Host Port | Guest IP   | Guest Port |
+|-----------|----------|-------------|-----------|------------|------------|
+| Rule 1    | TCP      | 127.0.0.1   | 1865      | 10.0.2.15  | 1865       |
+| Rule 2    | TCP      | 127.0.0.1   | 3000      | 10.0.2.15  | 3000       |
+
+If you want to work on the documentation of the Cat, you also have to add one rule for port 8000 which is used by `mkdocs`, and to configure `mkdocs` itself to respond to all requests (not only localhost as per the default).  
+
 ## Customization
 
 #### I want to build my own plugin for the Cat: what should I know about licensing?


### PR DESCRIPTION
As proposed in the discord server [here](https://discord.com/channels/1092359754917089350/1092591181730435112/1106264685210247259),  I am proposing to add to the FAQ  the configuration to run the cat inside a Virtual Machine