### PR TITLE
Added hook `before_collection_created` to override the first point inserted in memories

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -89,7 +89,7 @@ class CheshireCat:
 
     def load_memory(self):
         # Memory
-        vector_memory_config = {"embedder": self.embedder, "verbose": True}
+        vector_memory_config = {"cat": self, "verbose": True}
         self.memory = LongTermMemory(vector_memory_config=vector_memory_config)
         self.working_memory = WorkingMemory()
 

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -26,3 +26,12 @@ def after_cat_recalled_memories(user_message, cat):
 @hook(priority=0)
 def before_cat_sends_message(message, cat):
     return message
+
+
+# Hook called before inserting the first point in memory collection.
+# This happens at first lunch and whenever `long_term_memory` is deleted.
+# first_point is `langchain.Document` instance
+@hook(priority=0)
+def before_collection_created(first_point, cat):
+    return first_point
+

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -5,16 +5,19 @@ from typing import Any, Callable
 from cat.utils import log
 from qdrant_client import QdrantClient
 from langchain.vectorstores import Qdrant
+from langchain.docstore.document import Document
 from qdrant_client.http.models import Distance, VectorParams
 
 
 class VectorMemory:
-    def __init__(self, verbose=False, embedder=None) -> None:
+    def __init__(self, cat, verbose=False) -> None:
         self.verbose = verbose
 
-        if embedder is None:
+        # Get embedder from Cat instance
+        self.embedder = cat.embedder
+
+        if self.embedder is None:
             raise Exception("No embedder passed to VectorMemory")
-        self.embedder = embedder
 
         # Qdrant vector DB client
         self.vector_db = QdrantClient(
@@ -24,6 +27,7 @@ class VectorMemory:
 
         # Episodic memory will contain user and eventually cat utterances
         self.episodic = VectorMemoryCollection(
+            cat=cat,
             client=self.vector_db,
             collection_name="episodic",
             embedding_function=self.embedder.embed_query,
@@ -31,6 +35,7 @@ class VectorMemory:
 
         # Declarative memory will contain uploaded documents' content (and summaries)
         self.declarative = VectorMemoryCollection(
+            cat=cat,
             client=self.vector_db,
             collection_name="declarative",
             embedding_function=self.embedder.embed_query,
@@ -42,9 +47,13 @@ class VectorMemory:
 
 
 class VectorMemoryCollection(Qdrant):
-    def __init__(self, client: Any, collection_name: str, embedding_function: Callable):
+    def __init__(self, cat, client: Any, collection_name: str, embedding_function: Callable):
         super().__init__(client, collection_name, embedding_function)
 
+        # Get a Cat instance
+        self.cat = cat
+
+        # Check if memory collection exists, otherwise create it and add first memory
         self.create_collection_if_not_exists()
 
     def create_collection_if_not_exists(self):
@@ -64,10 +73,20 @@ class VectorMemoryCollection(Qdrant):
 
         # TODO: if the embedder changed, a new vectorstore must be created
         if tabula_rasa:
+            # Hard coded overridable first memory saved in both collections
+            first_memory = Document(page_content="I am the Cheshire Cat",
+                                    metadata={
+                                        "source": "cheshire-cat",
+                                        "when": time.time()
+                                    })
+
+            # Execute hook to override the first inserted memory
+            first_memory = self.cat.mad_hatter.execute_hook("before_collection_created", first_memory)
+
             # insert first point in the collection
             self.add_texts(
-                ["I am the Cheshire Cat"],
-                [{"source": "cheshire-cat", "when": time.time()}],
+                [first_memory.page_content],
+                [first_memory.metadata],
             )
 
         log(dict(self.client.get_collection(self.collection_name)))


### PR DESCRIPTION
I added the hook we discussed on the Discord.

Now `VectorMemory` expects an instance of the Cat and propagates it to the two `VectorMemoryCollections`. 
Please, let me know if it is done like you had in mind.

I followed the implementation of the [hook](https://github.com/pieroit/cheshire-cat/blob/8c7a961235cf424c48bb7f260fa8d118ea2df37a/core/cat/rabbit_hole.py#L141) you pointed out. Hence, `first_memory` is expected to be `langchain.Document`. 