### PR TITLE
Add hooks for translating documents / url

### DIFF
--- a/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
@@ -11,6 +11,18 @@ def before_rabbithole_insert_memory(doc, cat):
     return doc
 
 
+# Hook called just before rabbithole spilts text. Input is whole Document
+@hook(priority=0)
+def before_rabbithole_splits_text(doc, cat):
+    return doc
+
+
+# Hook called after rabbithole have spiltted text into chunks. Input is the chunks 
+@hook(priority=0)
+def after_rabbithole_splitted_text(chunks, cat):
+    return chunks
+
+
 # Hook called when a list of Document is summarized from the rabbit hole.
 # Should return a list of summaries (each is a langchain Document)
 # To deactivate summaries, override this hook and just return an empty list

--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -96,6 +96,8 @@ class RabbitHole:
         loader = UnstructuredURLLoader(urls=[url])
         text = loader.load()
 
+        text = self.cat.mad_hatter.execute_hook("before_rabbithole_splits_text", text)
+
         # split in documets using chunk_size and chunk_overlap
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=chunk_size,
@@ -103,6 +105,9 @@ class RabbitHole:
             separators=["\\n\\n", "\n\n", ".\\n", ".\n", "\\n", "\n", " ", ""],
         )
         docs = text_splitter.split_documents(text)
+
+        docs = self.cat.mad_hatter.execute_hook("after_rabbithole_splitted_text", docs)
+
         for doc in docs:
             doc.metadata["is_summary"] = False
         return docs
@@ -163,6 +168,8 @@ class RabbitHole:
         # extract text from file
         text = loader.load()
 
+        text = self.cat.mad_hatter.execute_hook("before_rabbithole_splits_text", text)
+
         # delete tmp file
         os.remove(temp_name)
 
@@ -177,6 +184,9 @@ class RabbitHole:
 
         # remove short texts (page numbers, isolated words, etc.)
         docs = list(filter(lambda d: len(d.page_content) > 10, docs))
+
+        docs = self.cat.mad_hatter.execute_hook("after_rabbithole_splitted_text", docs)
+
         for doc in docs:
             doc.metadata["is_summary"] = False
         return docs


### PR DESCRIPTION
As discussed on the discord channel it would be useful to have 2 hooks in the rabbit hole to allow external plugins to manipulate (eg translation) the content of the document or url.

The proposed hooks are:

before_rabbithole_splits_text(doc, cat) to be executed as soon as the document is loaded and before being split

after_rabbithole_splitted_text(chunks, cat) to execute after splitting the document into chunks

I have tested this hook with a multilingual plugin (currently in develop) and i have succefully translated document and url (from italian to english)
