### PR TITLE
Add hook after cat bootstrap

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -42,6 +42,8 @@ class CheshireCat:
         # Rabbit Hole Instance
         self.rabbit_hole = RabbitHole(self)
 
+        self.mad_hatter.execute_hook("init_cat")
+
     def load_db(self):
         # if there is no db, create it
         create_db_and_tables()

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -1,6 +1,11 @@
 from cat.mad_hatter.decorators import hook
 
 
+#Called after cat bootstrap
+@hook(priority=0)
+def init_cat(cat):
+    return None
+
 # Called when a user message arrives.
 # Useful to edit/enrich user input (e.g. translation)
 @hook(priority=0)


### PR DESCRIPTION
Adding an hook after cat bootstrap can be useful to dev for access cat instances (eg adding a value in working memory) when the cat bootstrap without waiting user interaction