### PR TITLE
Add support for PaLM and Claude #239 

### DIFF
--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -60,6 +60,28 @@ class LLMOpenAIChatConfig(LLMSettings):
             "description": "Chat model from OpenAI",
         }
 
+class LLMAnthropicConfig(LLMSettings):
+    anthropic_api_key: str
+    model: str = "claude-v1"
+    _pyclass: PyObject = langchain.chat_models.ChatAnthropic
+
+    class Config:
+        schema_extra = {
+            "name_human_readable": "Anthropic",
+            "description": "Configuration for Anthropic language Model",
+        }
+
+class LLMGooglePalmConfig(LLMSettings):
+    google_api_key: str
+    model_name: str = "models/text-bison-001"
+    _pyclass: PyObject = langchain.llms.GooglePalm
+
+    class Config:
+        schema_extra = {
+            "name_human_readable": "Google PaLM",
+            "description": "Configuration for Google PaLM language model",
+        }
+
 # https://learn.microsoft.com/en-gb/azure/cognitive-services/openai/reference#chat-completions
 class LLMAzureChatOpenAIConfig(LLMSettings):
     openai_api_key: str
@@ -88,7 +110,6 @@ class LLMCohereConfig(LLMSettings):
             "name_human_readable": "Cohere",
             "description": "Configuration for Cohere language model",
         }
-
 
 class LLMHuggingFaceHubConfig(LLMSettings):
     # model_kwargs = {
@@ -147,6 +168,8 @@ SUPPORTED_LANGUAGE_MODELS = [
     LLMHuggingFaceEndpointConfig,
     LLMAzureOpenAIConfig,
     LLMAzureChatOpenAIConfig,
+    LLMAnthropicConfig,
+    LLMGooglePalmConfig
 ]
 
 # LLM_SCHEMAS contains metadata to let any client know which fields are required to create the language model.

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -16,3 +16,5 @@ pdfminer.six==20221105
 unstructured==0.5.7
 tiktoken==0.3.3
 loguru==0.7.0
+anthropic==0.2.9
+google-generativeai==0.1.0rc3


### PR DESCRIPTION
This pull request resolves _add support for PaLM and Claude #239_. 
langchain.llms.Anthropic was marked as deprecated in the langchain class [here](https://python.langchain.com/en/latest/_modules/langchain/llms/anthropic.html) so I used ChatAnthropic instead.
I've also added to the dependencies "anthropic" and "google-generative" ai needed for these new LLMs to work.
I currently don't have access to an api key for those models but I've verified that after setting the model as default I get "401 unauthorized" error if I try to send a new message.