### PR TITLE
Upgrade to Azure API version 2023-05-15

### DIFF
--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -90,7 +90,8 @@ class LLMAzureChatOpenAIConfig(LLMSettings):
     model_name: str = "gpt-35-turbo"  # or gpt-4, use only chat models !
     openai_api_base: str
     openai_api_type: str = "azure"
-    openai_api_version: str = "2023-03-15-preview"
+    # Dont mix api versions https://github.com/hwchase17/langchain/issues/4775
+    openai_api_version: str = "2023-05-15"
 
     deployment_name: str
 
@@ -109,8 +110,9 @@ class LLMAzureOpenAIConfig(LLMSettings):
     openai_api_base: str
     api_type: str = "azure"
     # https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#completions
-    # Current supported versions 2022-12-01 or 2023-03-15-preview
-    api_version: str = "2023-03-15-preview"
+    # Current supported versions 2022-12-01, 2023-03-15-preview, 2023-05-15
+    # Don't mix api versions: https://github.com/hwchase17/langchain/issues/4775
+    api_version: str = "2023-05-15"
     deployment_name: str = "text-davinci-003"
     model_name: str = "text-davinci-003"  # Use only completion models !
 

--- a/core/cat/mad_hatter/core_plugin/hooks/models.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/models.py
@@ -92,8 +92,9 @@ def get_language_embedder(cat):
                 # "deployment": "my-text-embedding-ada-002",
                 "openai_api_base": cat.llm.openai_api_base,
                 # https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#embeddings
-                # current supported versions 2022-12-01 or 2023-03-15-preview
-                "openai_api_version": "2023-03-15-preview",
+                # current supported versions 2022-12-01,2023-03-15-preview, 2023-05-15
+                # Don't mix api versions https://github.com/hwchase17/langchain/issues/4775
+                "openai_api_version": "2023-05-15",
             }
         )
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/cognitive-services/openai/whats-new

If you are currently using the 2023-03-15-preview API, we recommend migrating to the GA 2023-05-15 API. If you are currently using API version 2022-12-01 this API remains GA, but does not include the latest Chat Completion capabilities.

@cristianorevil 