### PR TITLE
Dockerfile improvements

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,21 +1,35 @@
 
-FROM tiangolo/uvicorn-gunicorn:python3.10
+FROM python:3.10.11-slim-bullseye
 
 ### CORE ###
 
-COPY ./pyproject.toml pyproject.toml
-COPY ./cat/plugins ./cat/plugins
-COPY ./install_plugin_dependencies.py install_plugin_dependencies.py
+RUN mkdir -p /app && mkdir -p /admin
+COPY ./pyproject.toml /app/pyproject.toml
+COPY ./cat/plugins /app/cat/plugins
+COPY ./install_plugin_dependencies.py /app/install_plugin_dependencies.py
 WORKDIR /admin
 
-RUN pip install -U pip && \
-    pip install --no-cache-dir /app &&\
+RUN apt-get -y update && apt-get install -y curl xz-utils libmagic-mgc libmagic1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* &&\
+    NODEARCH= && dpkgArch="$(dpkg --print-architecture)" &&\
+    case "${dpkgArch##*-}" in \
+      amd64) NODEARCH='x64';; \
+      ppc64el) NODEARCH='ppc64le';; \
+      s390x) NODEARCH='s390x';; \
+      arm64) NODEARCH='arm64';; \
+      armhf) NODEARCH='armv7l';; \
+      i386) NODEARCH='x86';; \
+      *) echo "unsupported architecture"; exit 1 ;;\
+    esac &&\
+    pip install -U pip && \
+    pip install --no-cache-dir /app/ &&\
     python3 /app/install_plugin_dependencies.py &&\
 ### ADMIN (static build) ###
     curl -sL https://github.com/pieroit/cheshire-cat-admin/archive/main.tar.gz | tar xz -C /admin --strip-components=1 &&\
-    curl -fsSLO --compressed "https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz" &&\
-    tar -xJf node-v18.16.0-linux-x64.tar.xz -C /usr/local --strip-components=1 --no-same-owner &&\
-    rm node-v18.16.0-linux-x64.tar.xz &&\
+    curl -fsSLO --compressed "https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-${NODEARCH}.tar.xz" &&\
+    tar -xJf node-v18.16.0-linux-${NODEARCH}.tar.xz -C /usr/local --strip-components=1 --no-same-owner &&\
+    rm node-v18.16.0-linux-${NODEARCH}.tar.xz &&\
     ln -s /usr/local/bin/node /usr/local/bin/nodejs &&\
     npm install &&\
     npm run build

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,36 +1,26 @@
 
 FROM tiangolo/uvicorn-gunicorn:python3.10
 
-RUN apt-get update -y
-
-
 ### CORE ###
 
-#RUN apt-get install -y poppler-utils tesseract-ocr libreoffice ### needed form unstructured?
-
 COPY ./pyproject.toml pyproject.toml
-RUN pip install -U pip
-RUN pip install --no-cache-dir ./
-
 COPY ./cat/plugins ./cat/plugins
 COPY ./install_plugin_dependencies.py install_plugin_dependencies.py
+WORKDIR /admin
 
-RUN python3 install_plugin_dependencies.py
-
+RUN pip install -U pip && \
+    pip install --no-cache-dir /app &&\
+    python3 /app/install_plugin_dependencies.py &&\
+### ADMIN (static build) ###
+    curl -sL https://github.com/pieroit/cheshire-cat-admin/archive/main.tar.gz | tar xz -C /admin --strip-components=1 &&\
+    curl -fsSLO --compressed "https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz" &&\
+    tar -xJf node-v18.16.0-linux-x64.tar.xz -C /usr/local --strip-components=1 --no-same-owner &&\
+    rm node-v18.16.0-linux-x64.tar.xz &&\
+    ln -s /usr/local/bin/node /usr/local/bin/nodejs &&\
+    npm install &&\
+    npm run build
 
 ### ADMIN (static build) ###
-
-# install node
-WORKDIR /
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
-
-# clone admin sources
-RUN git clone https://github.com/pieroit/cheshire-cat-admin.git admin
-WORKDIR /admin
-# install and build
-RUN npm install && npm run build
-
 
 ### FINISH ###
 WORKDIR /app

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "loguru==0.7.0",
     "anthropic==0.2.9",
     "google-generativeai==0.1.0rc3",
+    "gunicorn==20.1.0",
+    "uvicorn[standard]==0.20.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
@pieroit this PR is proposed with 2 individual commits to give you the flexibility to review them independently.
You could decide to merge just 1 commit if changing the base image is a too big change.

Why we need this PR:

* Install `nodejs` manually to avoid deb package dependencies like `python-minimal:3.9`
* Change base docker image to `python:3.10.11-slim-bullseye` to reduce size, reduces image size to less than 1Gb (half the previous size)
* Makes possible to have an image that runs on at least `amd64` and `arm64` as native architectures
